### PR TITLE
new stuff

### DIFF
--- a/LockContention/lock-consoleapp/App.config
+++ b/LockContention/lock-consoleapp/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
     </startup>
 </configuration>

--- a/LockContention/lock-consoleapp/Program.cs
+++ b/LockContention/lock-consoleapp/Program.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using shared_remoting_lib;
+using System;
 using System.Runtime.Remoting.Channels.Ipc;
 using System.Security.Permissions;
-using shared_remoting_lib;
 
 namespace lock_consoleapp
 {
-    internal class Program
+	internal class Program
     {
         [SecurityPermission(SecurityAction.Demand)]
         public static void Main(string[] args)

--- a/LockContention/lock-consoleapp/lock-consoleapp.csproj
+++ b/LockContention/lock-consoleapp/lock-consoleapp.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>lock_consoleapp</RootNamespace>
     <AssemblyName>lock-consoleapp</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -28,9 +28,10 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -38,9 +39,10 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -48,18 +50,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestCertificateThumbprint>04FF0D56082F47520AD63AC2D8E74C70D5F7FA0E</ManifestCertificateThumbprint>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestKeyFile>lock-consoleapp_TemporaryKey.pfx</ManifestKeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <GenerateManifests>true</GenerateManifests>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -78,7 +69,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="lock-consoleapp_TemporaryKey.pfx" />
+    <Content Include="newrelic.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\shared-remoting-lib\shared-remoting-lib.csproj">

--- a/LockContention/lock-consoleapp/newrelic.config
+++ b/LockContention/lock-consoleapp/newrelic.config
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!-- Copyright (c) 2008-2020 New Relic, Inc.  All rights reserved. -->
+<!-- For more information see: https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/ -->
+<configuration xmlns="urn:newrelic-config" agentEnabled="true">
+	<service licenseKey="REPLACE_WITH_LICENSE_KEY" />
+	<application>
+		<name>lock-consoleapp</name>
+	</application>
+	<log level="info" />
+	<allowAllHeaders enabled="true" />
+	<attributes enabled="true">
+		<exclude>request.headers.cookie</exclude>
+		<exclude>request.headers.authorization</exclude>
+		<exclude>request.headers.proxy-authorization</exclude>
+		<exclude>request.headers.x-*</exclude>
+
+		<include>request.headers.*</include>
+	</attributes>
+	<transactionTracer enabled="true"
+		transactionThreshold="apdex_f"
+		stackTraceThreshold="500"
+		recordSql="obfuscated"
+		explainEnabled="false"
+		explainThreshold="500" />
+	<distributedTracing enabled="true" />
+	<errorCollector enabled="true">
+		<ignoreClasses>
+			<errorClass>System.IO.FileNotFoundException</errorClass>
+			<errorClass>System.Threading.ThreadAbortException</errorClass>
+		</ignoreClasses>
+		<ignoreStatusCodes>
+			<code>401</code>
+			<code>404</code>
+		</ignoreStatusCodes>
+	</errorCollector>
+	<browserMonitoring autoInstrument="true" />
+	<threadProfiling>
+		<ignoreMethod>System.Threading.WaitHandle:InternalWaitOne</ignoreMethod>
+		<ignoreMethod>System.Threading.WaitHandle:WaitAny</ignoreMethod>
+	</threadProfiling>
+  <instrumentation>
+    <applications>
+      <application name="lock-consoleapp.exe" />
+    </applications>
+  </instrumentation>
+</configuration>

--- a/LockContention/lock-webapp/Web.config
+++ b/LockContention/lock-webapp/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=301880
@@ -12,8 +12,8 @@
     <add key="NewRelic.AppName" value="lock-webapp" />
   </appSettings>
   <system.web>
-    <compilation debug="true" targetFramework="4.8" />
-    <httpRuntime targetFramework="4.8" />
+    <compilation debug="true" targetFramework="4.6.2" />
+    <httpRuntime targetFramework="4.6.2" />
   </system.web>
   <system.webServer>
     <handlers>
@@ -42,15 +42,15 @@
         <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35 "/>
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35 "/>
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>

--- a/LockContention/lock-webapp/lock-webapp.csproj
+++ b/LockContention/lock-webapp/lock-webapp.csproj
@@ -14,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>lock_webapp</RootNamespace>
     <AssemblyName>lock-webapp</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <Use64BitIISExpress />
@@ -25,6 +25,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,6 +35,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +45,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
@@ -51,18 +54,16 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -106,6 +107,7 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WebGrease">
       <Private>True</Private>
       <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>

--- a/LockContention/shared-remoting-lib/shared-remoting-lib.csproj
+++ b/LockContention/shared-remoting-lib/shared-remoting-lib.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>shared_remoting_lib</RootNamespace>
     <AssemblyName>shared-remoting-lib</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NewRelic.Api.Agent, Version=9.0.0.0, Culture=neutral, PublicKeyToken=06552fced0b33d87, processorArchitecture=MSIL">


### PR DESCRIPTION
Updates target frameworks to better match customer env.
- lock-consoleapp -> 4.5.2
- lock-webapp -> 4.6.2
- shared-remoting-lib -> 4.5.2

Updates all apps to not prefer 32bit and set CPU x64.

Creates a custom event called perfmon each time a set of methods are called that sends up the method name, "Contention Rate / sec", and "# of current logical Threads".  If the value is 0, nothing is sent to reprevent sending up tons of zeros (log showed a large number of them)

Methods with events in lock-consoleapp (really shared-remoting-lib ):
- RemoteObject.GetCount
- RemoteObject.CreateFailedDbConnection

Methods with events in lock-webapp:
- HomeController.Test
- HomeController.ThrowException
- HomeController.DoIpcStuff
- HomeController.CreateFailedDbConnectionViaIPC

Adds a local newrelic.config for lock-consoleapp to have it instrument the app.